### PR TITLE
feat: Add event submenu to sidebar navigation

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -18,7 +18,17 @@
           <h5 class="sidebar-title mt-2">QRevent</h5>
         </div>
         <div class="nav flex-column">
-          <a class="nav-link active" href="{% url 'event:home' %}">Events</a>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle active" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              Events
+            </a>
+            <ul class="dropdown-menu" data-bs-theme="dark">
+              <li><a class="dropdown-item" href="{% url 'event:home' %}">List Events</a></li>
+              <li><a class="dropdown-item" href="{% url 'event:crear_evento' %}">Create Event</a></li>
+              <li><a class="dropdown-item" href="{% url 'event:recepcion' %}">Reception</a></li>
+              <li><a class="dropdown-item" href="{% url 'event:estadisticas' %}">Statistics</a></li>
+            </ul>
+          </li>
           <a class="nav-link" href="{% url 'marketplace:product_list' %}">Marketplace</a>
           {% if user.is_authenticated %}
             <a class="nav-link" href="{% url 'users:dashboard' %}">Dashboard</a>
@@ -44,7 +54,17 @@
             <img src="{% static 'images/logo_qrevent.png' %}" alt="QRevent Logo" class="sidebar-logo">
             <h5 class="sidebar-title mt-2">QRevent</h5>
           </div>
-          <a class="nav-link active" href="{% url 'event:home' %}">Events</a>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle active" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              Events
+            </a>
+            <ul class="dropdown-menu" data-bs-theme="dark">
+              <li><a class="dropdown-item" href="{% url 'event:home' %}">List Events</a></li>
+              <li><a class="dropdown-item" href="{% url 'event:crear_evento' %}">Create Event</a></li>
+              <li><a class="dropdown-item" href="{% url 'event:recepcion' %}">Reception</a></li>
+              <li><a class="dropdown-item" href="{% url 'event:estadisticas' %}">Statistics</a></li>
+            </ul>
+          </li>
           <a class="nav-link" href="{% url 'marketplace:product_list' %}">Marketplace</a>
           {% if user.is_authenticated %}
             <a class="nav-link" href="{% url 'users:dashboard' %}">Dashboard</a>


### PR DESCRIPTION
This commit introduces a dropdown submenu for "Events" in the main sidebar.

The submenu includes links to:
- List Events
- Create Event
- Reception
- Statistics

This enhances navigation by grouping event-related actions under a single, easily accessible menu item in both desktop and mobile views.