### PR TITLE
Fix: Correct NoReverseMatch for profile URL in base.html

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -37,7 +37,7 @@
             <a class="nav-link" href="{% url 'users:dashboard' %}">Dashboard</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="{% url 'users:profile' %}">Profile</a>
+            <a class="nav-link" href="{% url 'users:profile_display' %}">Profile</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="{% url 'logout' %}">Logout</a>
@@ -86,7 +86,7 @@
               <a class="nav-link" href="{% url 'users:dashboard' %}">Dashboard</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="{% url 'users:profile' %}">Profile</a>
+              <a class="nav-link" href="{% url 'users:profile_display' %}">Profile</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="{% url 'logout' %}">Logout</a>


### PR DESCRIPTION
The template `templates/base.html` was using `{% url 'users:profile' %}` which caused a NoReverseMatch error because the actual URL name defined in `users/urls.py` is `profile_display`.

This commit updates the two occurrences of the profile link in `templates/base.html` to use `{% url 'users:profile_display' %}`.